### PR TITLE
Contact div overlaps gallery div

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -876,7 +876,7 @@ p {
 }
 
 #fh5co-contact {
-  padding: 3em 0;
+  padding: 3em;
   clear: both;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -876,13 +876,10 @@ p {
 }
 
 #fh5co-contact {
-  padding: 7em 0;
+  padding: 3em 0;
+  clear: both;
 }
-@media screen and (max-width: 768px) {
-  #fh5co-contact {
-    padding: 3em 0;
-  }
-}
+
 #fh5co-contact .form-control {
   border: none;
   box-shadow: none;


### PR DESCRIPTION
Hi Steve,

I've made a quick change to style.css which seems to have resolved an issue with the contact div overlapping with the gallery div above it, which lead to some inconsistent spacing on different screen sizes.