### PR TITLE
fix: Spacing issue for team members with small body on small screens

### DIFF
--- a/layouts/partials/team.html
+++ b/layouts/partials/team.html
@@ -6,7 +6,7 @@
       <p>{{ .description | markdownify }}</p>
     </div>
     {{ range .item }}
-    <div class="col-md-4">
+    <div class="col-md-4 col-xs-12">
       <div class="person">
 	<img src="{{ .img | absURL }}" alt="" class="img-responsive">
 	<h3>{{ .name }}</h3>


### PR DESCRIPTION
Team members with a short description would not fill up the entire width of the screen.

Before:
![before](https://i.imgur.com/voFppE3.png)

After:
![after](https://i.imgur.com/yoJ6V21.png)