### PR TITLE
Make images and section links relative to the root directory

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -11,7 +11,7 @@ title = "My Awesome Title"
 
 # Hero section (from here on is for icon theme)
 [params.hero]
-  img = "images/hero_bg.jpg"
+  img = "/images/hero_bg.jpg"
   title = "Create awesome things for better web"
   description = "Lovingly hand-crafted by the fine folks at [FreeHTML5.co](http://freehtml5.co/)"
 
@@ -32,13 +32,13 @@ title = "My Awesome Title"
     enable = true
 
     [[params.mission.images.list]]
-      img = "images/img_3.jpg"
+      img = "/images/img_3.jpg"
     [[params.mission.images.list]]
-      img = "images/img_2.jpg"
+      img = "/images/img_2.jpg"
     [[params.mission.images.list]]
-      img = "images/img_1.jpg"
+      img = "/images/img_1.jpg"
     [[params.mission.images.list]]
-      img = "images/img_4.jpg"
+      img = "/images/img_4.jpg"
 
   [[params.mission.item]]
     weight = 1
@@ -106,42 +106,42 @@ title = "My Awesome Title"
   [[params.work.item]]
     title = "Consectetur adipisicing"
     subtitle = "Web Design"
-    img = "images/img_1.jpg"
+    img = "/images/img_1.jpg"
 
   [[params.work.item]]
     title = "Consectetur adipisicing"
     subtitle = "Web Design"
-    img = "images/img_2.jpg"
+    img = "/images/img_2.jpg"
 
   [[params.work.item]]
     title = "Consectetur adipisicing"
     subtitle = "Web Design"
-    img = "images/img_3.jpg"
+    img = "/images/img_3.jpg"
 
   [[params.work.item]]
     title = "Consectetur adipisicing"
     subtitle = "Web Design"
-    img = "images/img_2.jpg"
+    img = "/images/img_2.jpg"
 
   [[params.work.item]]
     title = "Consectetur adipisicing"
     subtitle = "Web Design"
-    img = "images/img_3.jpg"
+    img = "/images/img_3.jpg"
 
   [[params.work.item]]
     title = "Consectetur adipisicing"
     subtitle = "Web Design"
-    img = "images/img_2.jpg"
+    img = "/images/img_2.jpg"
 
   [[params.work.item]]
     title = "Consectetur adipisicing"
     subtitle = "Web Design"
-    img = "images/img_3.jpg"
+    img = "/images/img_3.jpg"
 
   [[params.work.item]]
     title = "Consectetur adipisicing"
     subtitle = "Web Design"
-    img = "images/img_4.jpg"
+    img = "/images/img_4.jpg"
 
 # Team section
 [params.team]
@@ -153,7 +153,7 @@ title = "My Awesome Title"
     name = "Jean Doe"
     position = "Chief legend"
     description = "Lorem ipsum dolor sit amet consectetur adipisicing elit. Eveniet nam itaque ipsam iste provident quo ipsam iste provident."
-    img = "images/person1.jpg"
+    img = "/images/person1.jpg"
     email = "#"
     telephone = "#"
     facebook = "#"
@@ -168,7 +168,7 @@ title = "My Awesome Title"
     name = "Alice Doe"
     position = "Chief overlord"
     description = "Lorem ipsum dolor sit amet consectetur adipisicing elit. Eveniet nam itaque ipsam iste provident quo ipsam iste provident."
-    img = "images/person2.jpg"
+    img = "/images/person2.jpg"
     email = "#"
     telephone = "#"
     facebook = "#"
@@ -182,7 +182,7 @@ title = "My Awesome Title"
     name = "John Doe"
     position = "Chief haranguer"
     description = "Lorem ipsum dolor sit amet consectetur adipisicing elit. Eveniet nam itaque ipsam iste provident quo ipsam iste provident."
-    img = "images/person3.jpg"
+    img = "/images/person3.jpg"
     email = "#"
     telephone = "#"
     facebook = "#"
@@ -196,7 +196,7 @@ title = "My Awesome Title"
   #   name = "Jason Doe"
   #   position = "Chief haranguer"
   #   description = "Lorem ipsum dolor sit amet consectetur adipisicing elit. Eveniet nam itaque ipsam iste provident quo ipsam iste provident."
-  #   img = "images/person3.jpg"
+  #   img = "/images/person3.jpg"
   #   email = "#"
   #   telephone = "#"
   #   facebook = "#"
@@ -228,4 +228,4 @@ title = "My Awesome Title"
   vine = "#"
   linkedin = "#"
   instagram = "#"
-  
+

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -3,24 +3,26 @@
     <div class="container">
       <div class="fh5co-menu-1">
 
-	<a href="#" data-nav-section="home">{{ with .Site.Params.nav }}{{ if isset . "logo" }}<img src={{ .logo | absURL }} height="20" alt="">{{ end }}{{ if (not (isset . "logo")) }}Home{{ end }}{{ end }}</a>
+	<a href="/#" data-nav-section="home">{{ with .Site.Params.nav }}{{ if isset . "logo" }}<img src={{ .logo | absURL }} height="20" alt="">{{ end }}{{ if (not (isset . "logo")) }}Home{{ end }}{{ end }}</a>
 
 	{{ if .Site.Params.mission.enable }}
-	<a href="#" data-nav-section="mission">{{ with .Site.Params.nav.mission }}{{ . | markdownify }}{{ end }}</a>
+	<a href="/#" data-nav-section="mission">{{ with .Site.Params.nav.mission }}{{ . | markdownify }}{{ end }}</a>
 	{{ end }}
 
 	{{ if .Site.Params.services.enable }}
-	<a href="#" data-nav-section="services">{{ with .Site.Params.nav.services }}{{ . | markdownify }}{{ end }}</a>
+	<a href="/#" data-nav-section="services">{{ with .Site.Params.nav.services }}{{ . | markdownify }}{{ end }}</a>
 	{{ end }}
 
 	{{ if .Site.Params.team.enable }}
-	<a href="#" data-nav-section="team">{{ with .Site.Params.nav.team }}{{ . | markdownify }}{{ end }}</a>
+	<a href="/#" data-nav-section="team">{{ with .Site.Params.nav.team }}{{ . | markdownify }}{{ end }}</a>
 	{{ end }}
 
+  <a href="/blog" onclick="location.href='/blog';">Blog</a>
+
 	{{ if .Site.Params.contact.enable }}
-	<a href="#" data-nav-section="contact">{{ with .Site.Params.nav.contact }}{{ . | markdownify }}{{ end }}</a>
+	<a href="/#" data-nav-section="contact">{{ with .Site.Params.nav.contact }}{{ . | markdownify }}{{ end }}</a>
 	{{ end }}
-	
+
       </div>
     </div>
   </div>


### PR DESCRIPTION
On sub-pages, say for a blog, the navigation and images won't work because their paths are relative to the current directory.  This works well for single-page sites, where everything is always at the root, but not in this case.

We need to prepend a `/` to all of the locations so that we can explicitly state that all paths start at the root.