### PR TITLE
Convert contact form from netlify to formspree

### DIFF
--- a/layouts/partials/contact-form.html
+++ b/layouts/partials/contact-form.html
@@ -5,14 +5,14 @@
       <h2>{{ .title }}</h2>
       <p>{{ .message | markdownify }}</p>
       {{ end }}
-    </div>
-    <form name="contact-form" netlify-honeypot="_gotcha" action="thank-you" netlify>
+	</div>
+	<form action="//formspree.io/{{ with .Site.Params.contact }}{{ .recipient }}{{ end }}" method="post">
       <div class="row">
 	<div class="col-md-6">
 	  <div class="form-group">
 	    <!-- <label for="inputName">First name</label> -->
 		  {{ with .Site.Params.contact }}
-	    <input type="text" class="form-control" id="inputName" placeholder="{{ .name_placeholder }}" name="_name">
+	    <input type="text" class="form-control" id="inputName" placeholder="{{ .name_placeholder }}" name="name">
 		  {{ end }}
 	  </div>
 	</div>

--- a/layouts/partials/contact-form.html
+++ b/layouts/partials/contact-form.html
@@ -8,7 +8,7 @@
 	</div>
 	<form action="//formspree.io/{{ with .Site.Params.contact }}{{ .recipient }}{{ end }}" method="post">
       <div class="row">
-	<div class="col-md-6">
+	<div class="col-md-6 col-md-offset-3  text-center">
 	  <div class="form-group">
 	    <!-- <label for="inputName">First name</label> -->
 		  {{ with .Site.Params.contact }}
@@ -16,7 +16,7 @@
 		  {{ end }}
 	  </div>
 	</div>
-	<div class="col-md-6">
+	<div class="col-md-6 col-md-offset-3  text-center">
 	  <div class="form-group">
 			{{ with .Site.Params.contact }}
 	    <input type="email" class="form-control" id="inputEmail" placeholder="{{ .email_placeholder }}" name="_replyto" required>
@@ -24,7 +24,7 @@
 		  {{ end }}
 	  </div>
 	</div>
-	<div class="col-md-12">
+	<div class="col-md-6 col-md-offset-3  text-center">
 	  <div class="form-group">
 		  {{ with .Site.Params.contact }}
 	    <textarea class="form-control" id="inputBody" cols="30" rows="7" placeholder="{{ .message_placeholder }}" name="message"></textarea>
@@ -32,7 +32,7 @@
 	  </div>
 	</div>
 	<div class="col-md-12">
-	  <div class="form-group">
+	  <div class="form-group text-center">
 	    <input type="hidden" name="_subject" value="New website query">
 	    <input type="text" name="_gotcha" style="display:none">
 	    <button type="submit" class="btn btn-primary btn-outline" value="Send">{{ with .Site.Params.contact }}{{ .button_text }}{{ end }}</button>


### PR DESCRIPTION
This pull requests converts the contact form to formspree. It allows the site configuration to specify a `recipient` email address in the contact properties that is used to auto create the formspree form. Upon first submission on the live domain, the form will be activated.